### PR TITLE
gputest.py: Rename keys in VIRTUAL_NAME_INFO

### DIFF
--- a/misc/gputest.py
+++ b/misc/gputest.py
@@ -100,7 +100,7 @@ class GPUTest(Program):
         'webgl_conformance_vulkan_passthrough_tests': ['telemetry_gpu_integration_test', 'conformance/attribs'],
 
         'webgpu_blink_web_tests': ['webgpu_blink_web_tests', 'wpt_internal/webgpu/cts.html?q=webgpu:api,operation,render_pass,storeOp:*'],
-        'webgpu_blink_web_tests_with_backend_validation': ['webgpu_blink_web_tests', 'wpt_internal/webgpu/cts.html?q=webgpu:api,operation,render_pass,storeOp:*'],
+        'webgpu_blink_web_tests_with_partial_backend_validation': ['webgpu_blink_web_tests', 'wpt_internal/webgpu/cts.html?q=webgpu:api,operation,render_pass,storeOp:*'],
     }
 
     CHROME_CONFIG_FILES = ['chromium.gpu.fyi.json', 'chromium.dawn.json']


### PR DESCRIPTION
In chromium/src/testing/buildbot/chromium.dawn.json,
webgpu_blink_web_tests_with_backend_validation was renamed
webgpu_blink_web_tests_with_partial_backend_validation at
https://chromium-review.googlesource.com/c/chromium/src/+/3083298.